### PR TITLE
fix: call openlogin.logout on logout

### DIFF
--- a/src/modules/controllers.ts
+++ b/src/modules/controllers.ts
@@ -341,7 +341,7 @@ class ControllerModule extends VuexModule {
   }
 
   @Action
-  async logout(): Promise<Promise<Promise<Promise<void>>>> {
+  async logout(): Promise<void> {
     if (isMain && this.selectedAddress) {
       try {
         const openLoginInstance = await OpenLoginFactory.getInstance();
@@ -355,7 +355,6 @@ class ControllerModule extends VuexModule {
         window.location.href = "/";
       }
     }
-    this.updateTorusState(cloneDeep(DEFAULT_STATE));
     const { origin } = this.torus;
     this.torus.init({ _config: DEFAULT_CONFIG, _state: cloneDeep(DEFAULT_STATE) });
     this.torus.setOrigin(origin);


### PR DESCRIPTION
same behavior as torus wallet
add cloneDeep to DefaultState to prevent data mutation

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Logout without calling openlogin.logout is causing weird issue during login
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- added openlogin.logout during logout. Login weird issue will go away. 
- This fix only apply for browser that support 3rd party cookies 
- Fix for no 3rd party cookies will kid

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
