### PR TITLE
fix: lightmode styles on selectors, crashreport text

### DIFF
--- a/src/components/settings/CrashReporting.vue
+++ b/src/components/settings/CrashReporting.vue
@@ -16,14 +16,19 @@ const enabled = computed(() => ControllerModule.crashReport);
     <div class="flex items-center">
       <Switch
         :model="enabled"
-        :class="enabled ? 'bg-app-primary-500' : 'bg-app-primary-400'"
+        :class="enabled ? 'bg-app-primary-500' : 'bg-app-gray-600'"
         class="relative inline-flex items-center h-6 rounded-full w-11 mr-2"
         @update:model-value="(v) => ControllerModule.setCrashReport(!ControllerModule.crashReport)"
       >
         <span class="sr-only">{{ t("walletSettings.enableNotifications") }}</span>
-        <span :class="enabled ? 'translate-x-6' : 'translate-x-1'" class="inline-block w-4 h-4 transform bg-white rounded-full" />
+        <span
+          :class="enabled ? 'translate-x-6' : 'translate-x-1'"
+          class="inline-block w-4 h-4 transform bg-white rounded-full transition-transform"
+        />
       </Switch>
-      <div class="font-body text-app-text-500 dark:text-app-text-dark-500 text-sm">{{ t("walletSettings.crashReportIsEnabled") }}</div>
+      <div class="font-body text-app-text-500 dark:text-app-text-dark-500 text-sm">
+        {{ enabled ? t("walletSettings.crashReportIsEnabled") : t("walletSettings.crashReportIsDisabled") }}
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/tokens/NftSelect.vue
+++ b/src/components/tokens/NftSelect.vue
@@ -4,7 +4,6 @@ import { ChevronBottomIcon } from "@toruslabs/vue-icons/arrows";
 import { computed, ref, watch } from "vue";
 
 import { getTokenFromMint, nftTokens } from "@/components/transfer/token-helper";
-import { app } from "@/modules/app";
 import { getClubbedNfts } from "@/utils/helpers";
 
 const props = withDefaults(
@@ -25,7 +24,7 @@ watch(localMintAddress, () => {
 </script>
 <template>
   <Listbox v-model="localMintAddress" as="div" class="nft-select-container">
-    <div class="mt-1 relative" :class="{ dark: app.isDarkMode }">
+    <div class="mt-1 relative">
       <ListboxButton class="bg-white dark:bg-app-gray-700 select-container shadow-inner dark:shadow-none rounded-md w-full px-3">
         <span v-if="selectedNft?.metaplexData?.offChainMetaData" class="flex items-center">
           <div class="flex-shrink-0 h-6 w-6 rounded-full img-loader-container">

--- a/src/components/transfer/TransferTokenSelect.vue
+++ b/src/components/transfer/TransferTokenSelect.vue
@@ -8,7 +8,6 @@ import FallbackNft from "@/assets/nft.png";
 import NftLogo from "@/assets/nft_token.svg";
 import SolTokenLogo from "@/assets/sol_token.svg";
 import solicon from "@/assets/solana-mascot.svg";
-import { app } from "@/modules/app";
 import { getClubbedNfts, setFallbackImg } from "@/utils/helpers";
 import { SolAndSplToken } from "@/utils/interfaces";
 
@@ -35,7 +34,7 @@ watch(localToken, () => {
 <template>
   <Listbox v-model="localToken" as="div">
     <ListboxLabel class="block text-sm font-body text-app-text-600 dark:text-app-text-dark-500">{{ t("walletTransfer.selectItem") }}</ListboxLabel>
-    <div class="mt-1 relative" :class="{ dark: app.isDarkMode }">
+    <div class="mt-1 relative">
       <ListboxButton class="bg-white dark:bg-app-gray-800 select-container shadow-inner dark:shadow-none rounded-md w-full px-3">
         <span class="flex items-center">
           <img


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Transfer Selector, NFT Selector are always using dark mode styles.
Crash Report text always says enabled, button background is too bright for disabled state. 

## What is the new behavior?

- Fixed Selectors to use the selected theme.
- Crash report text displays correct state, change button background when disabled.

## Other information
