### PR TITLE
fix: use token address for unknown token

### DIFF
--- a/src/utils/instruction_decoder.ts
+++ b/src/utils/instruction_decoder.ts
@@ -1,6 +1,7 @@
 import * as bors from "@project-serum/borsh";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { PublicKey, StakeInstruction, StakeProgram, SystemInstruction, SystemProgram, Transaction, TransactionInstruction } from "@solana/web3.js";
+import { addressSlicer } from "@toruslabs/base-controllers";
 import { SolanaToken, TokenInfoController, TokenTransferData } from "@toruslabs/solana-controllers";
 import BN from "bignumber.js";
 import log from "loglevel";
@@ -352,17 +353,18 @@ export const constructTokenData = (
         // if tokenState (info) not found, assume unknown transaction
         if (!tokenState) return undefined;
         // Expect owner is signer (selectedAddress) as only signer spl transction go thru this function
-        const symbol = tokenState.isFungible
-          ? infoState.tokenInfoMap[tokenState.mintAddress].symbol
-          : infoState.metaplexMetaMap[tokenState.mintAddress].symbol;
+        let symbol = tokenState.isFungible
+          ? infoState.tokenInfoMap[tokenState.mintAddress]?.symbol
+          : infoState.metaplexMetaMap[tokenState.mintAddress]?.symbol;
+        if (!symbol) symbol = addressSlicer(tokenState.mintAddress);
 
         const logoURI = tokenState.isFungible
-          ? infoState.tokenInfoMap[tokenState.mintAddress].logoURI
-          : infoState.metaplexMetaMap[tokenState.mintAddress].offChainMetaData?.image;
+          ? infoState.tokenInfoMap[tokenState.mintAddress]?.logoURI
+          : infoState.metaplexMetaMap[tokenState.mintAddress]?.offChainMetaData?.image;
 
         const price = infoState.tokenPriceMap[tokenState.mintAddress];
         return {
-          tokenName: symbol as string | "unknown",
+          tokenName: symbol || "unknown",
           amount: decoded.data.amount as number,
           decimals: tokenState.balance?.decimals as number,
           from: new PublicKey(decoded.data.owner || "").toBase58(),

--- a/src/utils/instruction_decoder.ts
+++ b/src/utils/instruction_decoder.ts
@@ -364,7 +364,7 @@ export const constructTokenData = (
 
         const price = infoState.tokenPriceMap[tokenState.mintAddress];
         return {
-          tokenName: symbol || "unknown",
+          tokenName: symbol,
           amount: decoded.data.amount as number,
           decimals: tokenState.balance?.decimals as number,
           from: new PublicKey(decoded.data.owner || "").toBase58(),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
unknown token address ( not listed in spltoken list) will log error as it try to access member 'symbol' in contruct_token_data function

replace with address_slicer for unknown token address
 
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
unknown token address ( not listed in spltoken list) will log error as it try to access member 'symbol' in contruct_token_data function
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- replace with address_slicer for unknown token address
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
