### PR TITLE
fix: nft detail have error during sorting

### DIFF
--- a/src/pages/wallet/NftDetail.vue
+++ b/src/pages/wallet/NftDetail.vue
@@ -28,8 +28,8 @@ onMounted(async () => {
           return { ...val, stats };
         })
         .sort((a: any, b: any) => {
-          if (a.stats.weeklyVolume > b.stats.weeklyVolume) return -1;
-          if (a.stats.weeklyVolume < b.stats.weeklyVolume) return 1;
+          if (a.stats?.weeklyVolume > b.stats?.weeklyVolume) return -1;
+          if (a.stats?.weeklyVolume < b.stats?.weeklyVolume) return 1;
           return 0;
         });
       exploreNFTS.value = combinedCollectionObject.slice(0, 10) as any;

--- a/src/pages/wallet/NftDetail.vue
+++ b/src/pages/wallet/NftDetail.vue
@@ -28,8 +28,10 @@ onMounted(async () => {
           return { ...val, stats };
         })
         .sort((a: any, b: any) => {
-          if (a.stats?.weeklyVolume > b.stats?.weeklyVolume) return -1;
-          if (a.stats?.weeklyVolume < b.stats?.weeklyVolume) return 1;
+          if (a.stats === undefined) return 1;
+          if (b.stats === undefined) return -1;
+          if (a.stats.weeklyVolume > b.stats.weeklyVolume) return -1;
+          if (a.stats.weeklyVolume < b.stats.weeklyVolume) return 1;
           return 0;
         });
       exploreNFTS.value = combinedCollectionObject.slice(0, 10) as any;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
nft detail page compute collection object throw error

`a.stats` might be undefined

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
nft page do not show default content when user do not have any nft

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
mod to `a.stat?`
Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- show default content
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
