### PR TITLE
Amount input field on transfer page should not allow to transfer empty amount 

### DIFF
--- a/src/pages/wallet/Transfer.vue
+++ b/src/pages/wallet/Transfer.vue
@@ -183,6 +183,7 @@ const rules = computed(() => {
       tokenAddress: helpers.withMessage(t("walletTransfer.invalidAddress"), helpers.withAsync(tokenAddressVerifier)),
     },
     sendAmount: {
+      required: helpers.withMessage(t("walletTransfer.minTransfer"), required),
       greaterThanZero: helpers.withMessage(t("walletTransfer.minTransfer"), minValue(isCurrencyFiat.value ? convertCryptoToFiat(0.0001) : 0.0001)),
       lessThanBalance: helpers.withMessage(
         t("walletTransfer.insufficientBalance"),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

-  Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- empty amount field on transfer page is allowing to transfer

Issue Number: N/A

## What is the new behavior?

- it will show an error that amount field can not be empty while transfering.


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
