### PR TITLE
fix: tempKey is PublicKey

### DIFF
--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -1235,7 +1235,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
     // stored locally
     // const tempKey = new Keypair().secretKey.slice(32, 64);
     const tempKeyPair = new Keypair(); // .secretKey.slice(32, 64);
-    const tempKey = tempKeyPair.secretKey.slice(32, 64);
+    const tempKey = tempKeyPair.secretKey.slice(0, 32);
 
     // (ephemeral private key, user public key)
     const keyState: KeyState = {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
The key use for state encryption is the public Key.
update using index 0..32 instead of 32..64

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
using public key to encrypt state
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- use key index [0..32] to encrypt state
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
