### PR TITLE
fix: sendTransaction using Message need blockhash

### DIFF
--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -1440,8 +1440,11 @@ export default class TorusController extends BaseController<TorusControllerConfi
     if (!message) throw new Error("empty error message");
 
     let tx: Transaction;
-    if (req.params?.messageOnly) tx = Transaction.populate(Message.from(Buffer.from(message, "hex")));
-    else tx = Transaction.from(Buffer.from(message, "hex"));
+    if (req.params?.messageOnly) {
+      tx = Transaction.populate(Message.from(Buffer.from(message, "hex")));
+      const block = await this.connection.getLatestBlockhash("max");
+      tx.recentBlockhash = block.blockhash;
+    } else tx = Transaction.from(Buffer.from(message, "hex"));
 
     return this.transfer(tx, req);
   }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Append blockhash for embed's sendTransaction with MessageOnly flag
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Fail to sendTransaction from embed if sendTransaction from embed with MessageOnly Flag.
This is due to Transaction populated from Message do not have blockhash

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- set blockhash for sendTransaction from embed with MessageOnly Flag
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
