### PR TITLE
fix: display significant digit ui

### DIFF
--- a/src/components/TokenBalance.vue
+++ b/src/components/TokenBalance.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { significantDigits } from "@toruslabs/base-controllers";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
@@ -26,8 +27,8 @@ const setConversionRate = async () => {
 };
 
 const formattedBalance = computed(() => {
-  if (token.value === "SOL") return ControllerModule.solBalance.toFixed(4);
-  return Number(props.selectedToken?.balance?.uiAmount).toFixed(2);
+  if (token.value === "SOL") return significantDigits(ControllerModule.solBalance, false, 4);
+  return significantDigits(props.selectedToken?.balance?.uiAmount || 0, false, 4);
 });
 watch(
   () => props.selectedToken,

--- a/src/components/home/SplCard.vue
+++ b/src/components/home/SplCard.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { significantDigits } from "@toruslabs/base-controllers";
-import BigNumber from "bignumber.js";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
@@ -44,8 +43,8 @@ function splClicked() {
         <img class="block h-5 mr-2 w-auto text-white font-bold text-xs leading-3" :src="splToken?.iconURL" alt="TOKEN Logo" />
         <p class="text-app-text-600 dark:text-app-text-dark-500 font-bold text-xs leading-3 w-24 truncate">{{ splToken?.name }}</p></span
       >
-      <p class="font-medium text-xs leading-3 text-right text-gray-900 text-app-text-600 dark:text-app-text-dark-500 mr-1 truncate w-20">
-        ~ {{ significantDigits(new BigNumber(splToken.balance?.uiAmountString || "0"), false, 4) }} {{ splToken?.symbol }}
+      <p class="font-medium text-xs leading-3 text-right text-app-text-600 dark:text-app-text-dark-500 mr-1 truncate w-20">
+        ~ {{ significantDigits(splToken.balance?.uiAmount || 0, false, 4) }} {{ splToken?.symbol }}
       </p>
     </div>
     <div class="flex flex-row justify-between items-center font-normal text-gray-500 text-xs flex-auto px-4">

--- a/src/components/home/SplCard.vue
+++ b/src/components/home/SplCard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { significantDigits } from "@toruslabs/base-controllers";
+import BigNumber from "bignumber.js";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
@@ -32,6 +34,7 @@ function splClicked() {
 
 <template>
   <div
+    v-if="splToken"
     class="shadow dark:shadow_box cursor-pointer border border-app-gray-300 dark:border-transparent bg-white dark:bg-app-gray-700 rounded-md h-20 flex flex-col justify-center"
     @click="splClicked"
     @keydown="splClicked"
@@ -42,7 +45,7 @@ function splClicked() {
         <p class="text-app-text-600 dark:text-app-text-dark-500 font-bold text-xs leading-3 w-24 truncate">{{ splToken?.name }}</p></span
       >
       <p class="font-medium text-xs leading-3 text-right text-gray-900 text-app-text-600 dark:text-app-text-dark-500 mr-1 truncate w-20">
-        ~ {{ (+(splToken?.balance?.uiAmountString ?? "0"))?.toFixed(3) }} {{ splToken?.symbol }}
+        ~ {{ significantDigits(new BigNumber(splToken.balance?.uiAmountString || "0"), false, 4) }} {{ splToken?.symbol }}
       </p>
     </div>
     <div class="flex flex-row justify-between items-center font-normal text-gray-500 text-xs flex-auto px-4">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
fix token card's token digit ui display with 4 significant digits

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
currently digit ui display is toFixed to 3 decimals
balance with less than 0.001 will have display issue 

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-  digit ui display with 4 significant digits
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
