### PR TITLE
[SOL-195]: Add sentry tags for richer events.

### DIFF
--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -474,7 +474,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
             this.tokensTracker.state.tokens ? this.tokensTracker.state.tokens[this.selectedAddress] : []
           );
           this.preferencesController.patchNewTx(state2.transactions[txId], this.selectedAddress, tokenTransfer).catch((err) => {
-            log.error("error while patching a new tx", err);
+            log.error(err, "error while patching a new tx");
           });
         }
       });
@@ -1276,7 +1276,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
       });
       window.localStorage?.setItem(EPHERMAL_KEY, stringify(keyState));
     } catch (error) {
-      log.error("Error saving state!", error);
+      log.error(error, "Error saving state!");
     }
   }
 
@@ -1335,7 +1335,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
         this.handleLogout();
       }
     } catch (error) {
-      log.error("Error restoring state!", error);
+      log.error(error, "Error restoring state!");
       this.handleLogout();
     }
   }

--- a/src/modules/controllers.ts
+++ b/src/modules/controllers.ts
@@ -509,7 +509,7 @@ class ControllerModule extends VuexModule {
       // window.localStorage?.removeItem(CONTROLLER_MODULE_KEY);
       window.localStorage?.removeItem(EPHERMAL_KEY);
     } catch (error) {
-      log.error("LocalStorage unavailable");
+      log.error(new Error("LocalStorage unavailable"));
     }
   }
 

--- a/src/pages/Confirm.vue
+++ b/src/pages/Confirm.vue
@@ -130,7 +130,7 @@ onMounted(async () => {
       log.error(e);
     }
   } catch (error) {
-    log.error("error in tx", error);
+    log.error(error, "error in tx");
   }
 });
 

--- a/src/pages/ConfirmMessage.vue
+++ b/src/pages/ConfirmMessage.vue
@@ -47,7 +47,7 @@ onMounted(async () => {
     msg_data.message = (channel_msg.message as string) || "";
     msg_data.origin = channel_msg.origin as string;
   } catch (error) {
-    log.error("error in tx", error);
+    log.error(error, "error in tx");
   }
 });
 

--- a/src/pages/wallet/NftDetail.vue
+++ b/src/pages/wallet/NftDetail.vue
@@ -40,7 +40,7 @@ onMounted(async () => {
       exploreNFTS.value = combinedCollectionObject.slice(0, 10) as any;
       exploreNFTSFetchState.value = "loaded";
     } catch (error) {
-      log.error("Could not fetch example NFTs");
+      log.error(new Error("Could not fetch example NFTs"));
       exploreNFTSFetchState.value = "error";
       exploreNFTS.value = [];
     }

--- a/src/plugins/i18nPlugin.ts
+++ b/src/plugins/i18nPlugin.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/vue";
 import log from "loglevel";
 import { nextTick } from "vue";
 import { createI18n, I18n } from "vue-i18n";
@@ -41,7 +42,8 @@ export async function loadLocaleMessages(i18n: I18n, locale: any) {
     // set locale and locale message
     i18n.global.setLocaleMessage(lang, messages.default);
   } catch (e) {
-    log.error(`REQUESTED UNKNOWN LOCALE ${lang}: ${JSON.stringify(e)}`);
+    log.error(e, `REQUESTED UNKNOWN LOCALE ${lang}`);
+    Sentry.setTag("unknown-locale", lang);
   }
   return nextTick();
 }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -47,11 +47,12 @@ export function installSentry(Vue: App) {
       }
 
       // do not track events on dev environment
-      return null;
+      return e;
     },
   });
   // Sentry.setUser({ email: "john.doe@example.com" });
 
   const plugin = new LoglevelSentryPlugin(Sentry);
+  Sentry.setTag("referrer", document.referrer || "self");
   plugin.install(log);
 }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -47,7 +47,7 @@ export function installSentry(Vue: App) {
       }
 
       // do not track events on dev environment
-      return e;
+      return null;
     },
   });
   // Sentry.setUser({ email: "john.doe@example.com" });

--- a/src/utils/ErrorHandler.ts
+++ b/src/utils/ErrorHandler.ts
@@ -1,9 +1,14 @@
+import * as Sentry from "@sentry/vue";
+
 import { addToast, removeToast } from "@/modules/app";
 import { i18n } from "@/plugins/i18nPlugin";
 
 const { t } = i18n.global;
 export function handleExceptions(e: any): void {
   if (e.exception?.values?.[0]?.value?.includes("Network request failed")) {
+    // subsequent error which are not network errors will have the tag that there was a rpc error in the past for this session.
+    // which might be a possible explanation of error in inspection
+    Sentry.setTag("rpc-error", Date.now());
     const rpcNetworkError: any = { type: "warning", message: t("walletSettings.changeNetworkError") };
     removeToast(rpcNetworkError); // remove existing rpcNetworkError toasts
     addToast(rpcNetworkError); // show rpcNetworkError

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -227,7 +227,7 @@ export async function recordDapp(origin: string) {
     };
     await post(`${config.api}/dapps/record`, { ...recordLoginPayload });
   } catch (e) {
-    log.error("ERROR RECORDING DAPP", e);
+    log.error(e, "ERROR RECORDING DAPP");
   }
 }
 export const backendStatePromise = promiseCreator();


### PR DESCRIPTION
- added simple text in error block to have stacktrace
-  the loglevel library that we have has first parametre as the error, and the second one as the extra, hence flipped some log.errors to match this signature.
- added tags at 1. If RPC error has ever happened in the session, if locale error was found, and the referrer of the session.