### PR TITLE
fix: using dappUrl's origin as idx key

### DIFF
--- a/src/components/discover/DappItem.vue
+++ b/src/components/discover/DappItem.vue
@@ -18,8 +18,8 @@ const onDappClick = () => {
   const dappOriginURL = sessionStorage.getItem(instanceId);
 
   if (dappOriginURL) {
-    const urlTrimmed = props.dapp.url.at(-1) === "/" ? props.dapp.url.slice(0, -1) : props.dapp.url;
-    localStorage.setItem(`dappOriginURL-${urlTrimmed}`, dappOriginURL);
+    const dappUrl = new URL(props.dapp.url);
+    localStorage.setItem(`dappOriginURL-${dappUrl.origin}`, dappOriginURL);
   }
 };
 </script>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
use dappUrl's origin as idx key
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
trimmed `/` from the url only instead of using url origin

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- use dap purl's origin as idx key
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
