### PR TITLE
fix: use ed25519 for privatekey login

### DIFF
--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -415,7 +415,12 @@ export default class TorusController extends BaseController<TorusControllerConfi
     // ensure accountTracker updates balances after network change
     this.networkController.on("networkDidChange", async () => {
       if (this.selectedAddress) {
-        this.preferencesController.initializeDisplayActivity();
+        try {
+          this.preferencesController.initializeDisplayActivity();
+        } catch (e) {
+          log.error(this.selectedAddress);
+          log.error(e);
+        }
       }
 
       this.engine?.emit("notification", {
@@ -652,7 +657,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
   }
 
   async addAccount(privKey: string, userInfo?: UserInfo, rehydrate?: boolean): Promise<string> {
-    const address = this.keyringController.importAccount(privKey);
+    const address = this.keyringController.importKeyring(base58.decode(privKey));
     if (userInfo) {
       // try catch to prevent breaking login flow
       try {
@@ -1202,8 +1207,12 @@ export default class TorusController extends BaseController<TorusControllerConfi
       // Need to clear preference selectedAddress on Login
       // Do not need this due to save state to SessionStorage
 
-      const address = await this.addAccount(paddedKey, userInfo);
+      const keypair = getED25519Key(paddedKey);
+      const address = await this.addAccount(base58.encode(keypair.sk), userInfo);
       this.setSelectedAccount(address);
+      if (!this.privateKey) throw new Error("Wallet Error: Invalid private key ");
+      this.saveToOpenloginBackend({ privateKey: base58.encode(keypair.sk), publicKey: this.selectedAddress, userInfo });
+
       this.emit("LOGIN_RESPONSE", null, address);
       return result;
     } catch (error) {
@@ -1295,10 +1304,10 @@ export default class TorusController extends BaseController<TorusControllerConfi
   }
 
   async saveToOpenloginBackend(saveState: OpenLoginBackendState) {
-    const { privateKey } = saveState;
+    // const { privateKey: secretKey, publicKey } = saveState;
 
     // openlogin derived ED255519
-    const { pk: publicKey, sk: secretKey } = getED25519Key(privateKey.padStart(64, "0"));
+    // const { pk: publicKey, sk: secretKey } = getED25519Key(privateKey.padStart(64, "0"));
 
     // Random generated secp256k1
     const ecc_privateKey = eccrypto.generatePrivate();
@@ -1314,7 +1323,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
       window.localStorage?.setItem(`${EPHERMAL_KEY}-${this.origin}`, stringify(keyState));
       // save encrypted ed25519
       await this.storageLayer?.setMetadata<OpenLoginBackendState>({
-        input: { publicKey: base58.encode(publicKey), privateKey: base58.encode(secretKey), userInfo: this.userInfo },
+        input: saveState,
         privKey: new BN(ecc_privateKey),
       });
     } catch (error) {
@@ -1358,7 +1367,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
 
           log.info("login without userinfo");
           // Restore keyringController only ( no Sync / initPreferenes )
-          address = await this.addAccount(base58.decode(decryptedState.privateKey).toString("hex").slice(0, 64));
+          address = await this.addAccount(decryptedState.privateKey);
 
           // required to set selectedAddress before check for jwt
           this.preferencesController.setSelectedAddress(address);
@@ -1374,7 +1383,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
           }
         } else {
           // restore with userInfo ( full login as preference state not available )
-          address = await this.addAccount(base58.decode(decryptedState.privateKey).toString("hex").slice(0, 64), decryptedState.userInfo);
+          address = await this.addAccount(decryptedState.privateKey, decryptedState.userInfo);
         }
 
         // This call sync and refresh blockchain state
@@ -1598,7 +1607,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
     this.setSelectedAccount(publicKey);
 
     if (!this.hasSelectedPrivateKey) throw new Error("Waller Error");
-    this.saveToOpenloginBackend({ privateKey: req.params?.privateKey, publicKey: this.selectedAddress });
+    this.saveToOpenloginBackend({ privateKey: req.params?.privateKey, publicKey: this.selectedAddress, userInfo: req.params?.userInfo });
 
     this.engine?.emit("notification", {
       method: PROVIDER_NOTIFICATIONS.UNLOCK_STATE_CHANGED,

--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -418,8 +418,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
         try {
           this.preferencesController.initializeDisplayActivity();
         } catch (e) {
-          log.error(this.selectedAddress);
-          log.error(e);
+          log.error(e, this.selectedAddress);
         }
       }
 

--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -1209,7 +1209,8 @@ export default class TorusController extends BaseController<TorusControllerConfi
       const keypair = getED25519Key(paddedKey);
       const address = await this.addAccount(base58.encode(keypair.sk), userInfo);
       this.setSelectedAccount(address);
-      if (!this.privateKey) throw new Error("Wallet Error: Invalid private key ");
+
+      if (!this.hasSelectedPrivateKey) throw new Error("Wallet Error: Invalid private key ");
       this.saveToOpenloginBackend({ privateKey: base58.encode(keypair.sk), publicKey: this.selectedAddress, userInfo });
 
       this.emit("LOGIN_RESPONSE", null, address);
@@ -1303,11 +1304,6 @@ export default class TorusController extends BaseController<TorusControllerConfi
   }
 
   async saveToOpenloginBackend(saveState: OpenLoginBackendState) {
-    // const { privateKey: secretKey, publicKey } = saveState;
-
-    // openlogin derived ED255519
-    // const { pk: publicKey, sk: secretKey } = getED25519Key(privateKey.padStart(64, "0"));
-
     // Random generated secp256k1
     const ecc_privateKey = eccrypto.generatePrivate();
     const ecc_publicKey = eccrypto.getPublic(ecc_privateKey);
@@ -1600,8 +1596,6 @@ export default class TorusController extends BaseController<TorusControllerConfi
     if (!req.params?.privateKey) throw new Error("Invalid Private Key");
 
     // Do not need this as embed restore trigger moved to on 'requestAccount` called and state save in SessionStorage
-    // this.keyringController.update({ wallets: [] });
-    // this.preferencesController.update({ identities: {}, selectedAddress: "" });
     const publicKey = await this.addAccount(req.params?.privateKey, req.params?.userInfo);
     this.setSelectedAccount(publicKey);
 

--- a/src/modules/controllers.ts
+++ b/src/modules/controllers.ts
@@ -464,8 +464,7 @@ class ControllerModule extends VuexModule {
   @Action
   async triggerLogin({ loginProvider, login_hint }: { loginProvider: LOGIN_PROVIDER_TYPE; login_hint?: string }): Promise<void> {
     // do not need to restore beyond login
-    const res = await this.torus.triggerLogin({ loginProvider, login_hint });
-    this.torus.saveToOpenloginBackend({ privateKey: res.privKey, publicKey: this.selectedAddress });
+    await this.torus.triggerLogin({ loginProvider, login_hint });
   }
 
   @Action


### PR DESCRIPTION
fix importAccount issue
use ed25519 key for private key login

fix importAccount which mix secp256k1 and ed25519 key

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
using secp256k1 key for privatekey login
use ed25519 for all type of account import
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- use ed25519 key for private key login
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
