### PR TITLE
fix: transfer token select ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@bonfida/spl-name-service": "^0.1.27",
     "@gtm-support/vue-gtm": "^1.4.0",
-    "@headlessui/vue": "^1.6.0",
+    "@headlessui/vue": "^1.6.1",
     "@heroicons/vue": "^1.0.6",
     "@metaplex-foundation/mpl-token-metadata": "^1.2.4",
     "@project-serum/borsh": "^0.2.5",


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Transfer page's token select is not full width due to @headlessui/vue version 1.6.0 which updated recently.
update to latest @headlessui/vue v1.6.1
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Transfer'page select token is not full width
![Screenshot 2022-05-09 at 4 46 40 PM](https://user-images.githubusercontent.com/4881057/167374037-0c9d2c24-0c1d-48ce-a9ca-9cf7888fc79d.png)

Issue Number: N/A

## What is the new behavior?
![Screenshot 2022-05-09 at 4 47 20 PM](https://user-images.githubusercontent.com/4881057/167374163-fdb14eff-f4ec-4af1-b2be-2b42abdce975.png)

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
