### PR TITLE
Feat/dapp derive key

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@toruslabs/openlogin": "^1.7.4",
     "@toruslabs/openlogin-ed25519": "^1.7.0",
     "@toruslabs/openlogin-jrpc": "^1.7.3",
+    "@toruslabs/openlogin-subkey": "^1.7.2",
     "@toruslabs/openlogin-utils": "^1.7.0",
     "@toruslabs/solana-controllers": "^1.6.17",
     "@toruslabs/tweetnacl-js": "^1.0.3",

--- a/src/components/discover/DappItem.vue
+++ b/src/components/discover/DappItem.vue
@@ -7,11 +7,13 @@ const props = defineProps<{
   dapp: DiscoverDapp;
 }>();
 
-const onDappClick = () => {
-  const searchParams = new URLSearchParams(window.location.search);
-  const instanceId = searchParams.get("instanceId") || "";
-  const dappOriginURL = sessionStorage.getItem(instanceId);
+// move these to controller module ?
+const searchParams = new URLSearchParams(window.location.search);
+const instanceId = searchParams.get("instanceId") || "";
+const dappOriginURL = sessionStorage.getItem(instanceId);
+const w3aClientID = sessionStorage.getItem("w3aClientID");
 
+const onDappClick = () => {
   if (dappOriginURL) {
     const dappUrl = new URL(props.dapp.url);
     localStorage.setItem(`dappOriginURL-${dappUrl.origin}`, dappOriginURL);
@@ -19,10 +21,14 @@ const onDappClick = () => {
 };
 
 const logo = computed(() => props.dapp?.logo?.[0].url || "");
+const targetUrl = computed(() => {
+  if (dappOriginURL && w3aClientID) return `${props.dapp.url}?dappOriginURL=${dappOriginURL}&w3aClientID=${w3aClientID}`;
+  return props.dapp.url;
+});
 </script>
 <template>
   <a
-    :href="dapp.url"
+    :href="targetUrl"
     class="flex bg-white hover:bg-app-gray-200 dark:bg-app-gray-700 border border-app-gray-200 dark:border-transparent shadow dark:shadow-dark rounded-lg p-4"
     rel="noreferrer noopener"
     @click="onDappClick"

--- a/src/components/discover/DappItem.vue
+++ b/src/components/discover/DappItem.vue
@@ -9,9 +9,7 @@ const props = defineProps<{
 
 // move these to controller module ?
 const searchParams = new URLSearchParams(window.location.search);
-const instanceId = searchParams.get("instanceId") || "";
-const dappOriginURL = sessionStorage.getItem(instanceId);
-const w3aClientID = sessionStorage.getItem("w3aClientID");
+const dappOriginURL = searchParams.get("dappOriginURL");
 
 const onDappClick = () => {
   if (dappOriginURL) {
@@ -22,7 +20,7 @@ const onDappClick = () => {
 
 const logo = computed(() => props.dapp?.logo?.[0].url || "");
 const targetUrl = computed(() => {
-  if (dappOriginURL && w3aClientID) return `${props.dapp.url}?dappOriginURL=${dappOriginURL}&w3aClientID=${w3aClientID}`;
+  if (dappOriginURL) return `${props.dapp.url}?dappOriginURL=${dappOriginURL}`;
   return props.dapp.url;
 });
 </script>

--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -1322,6 +1322,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
 
     try {
       window.localStorage?.setItem(`${EPHERMAL_KEY}-${this.origin}`, stringify(keyState));
+      window.sessionStorage?.setItem(`${EPHERMAL_KEY}-${this.origin}`, stringify(keyState));
       // save encrypted ed25519
       await this.storageLayer?.setMetadata<OpenLoginBackendState>({
         input: saveState,
@@ -1341,7 +1342,8 @@ export default class TorusController extends BaseController<TorusControllerConfi
     try {
       const dappStorageKey = this.getDappStorageKey();
       log.info(dappStorageKey);
-      const value = window.localStorage?.getItem(`${EPHERMAL_KEY}-${dappStorageKey}`);
+      const value =
+        window.localStorage?.getItem(`${EPHERMAL_KEY}-${dappStorageKey}`) || window.sessionStorage.getItem(`${EPHERMAL_KEY}-${dappStorageKey}`);
 
       const keyState: KeyState =
         typeof value === "string"

--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -1373,7 +1373,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
         log.info("try to restore key");
         let address;
         try {
-          if (this.preferencesController.state.identities[decryptedState.publicKey]) {
+          if (this.preferencesController.state.identities[decryptedState.publicKey]?.jwtToken) {
             // Try key restore with session state intact.
             // Using LocalStorage to save state, hence could not check with selected address
             // if (decryptedState.publicKey !== this.selectedAddress) throw new Error("Incorrect public address");
@@ -1393,14 +1393,14 @@ export default class TorusController extends BaseController<TorusControllerConfi
               if (expire < Date.now() / 1000) {
                 await this.refreshJwt();
               }
+            } else {
+              // restore with userInfo ( full login as preference state not available )
+              address = await this.addAccount(decryptedState.privateKey, decryptedState.userInfo);
             }
-          } else {
-            // restore with userInfo ( full login as preference state not available )
-            address = await this.addAccount(decryptedState.privateKey, decryptedState.userInfo);
+            // This call sync and refresh blockchain state
+            this.setSelectedAccount(address, true);
+            return true;
           }
-          // This call sync and refresh blockchain state
-          this.setSelectedAccount(address, true);
-          return true;
         } catch (e) {
           log.error(e, "Error restoring state after successfull decrypt!");
         }

--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -1414,14 +1414,14 @@ export default class TorusController extends BaseController<TorusControllerConfi
               if (expire < Date.now() / 1000) {
                 await this.refreshJwt();
               }
-            } else {
-              // restore with userInfo ( full login as preference state not available )
-              address = await this.addAccount(decryptedState.privateKey, decryptedState.userInfo);
             }
-            // This call sync and refresh blockchain state
-            this.setSelectedAccount(address, true);
-            return true;
+          } else {
+            // restore with userInfo ( full login as preference state not available )
+            address = await this.addAccount(decryptedState.privateKey, decryptedState.userInfo);
           }
+          // This call sync and refresh blockchain state
+          this.setSelectedAccount(address, true);
+          return true;
         } catch (e) {
           log.error(e, "Error restoring state after successfull decrypt!");
         }

--- a/src/modules/controllers.ts
+++ b/src/modules/controllers.ts
@@ -41,7 +41,7 @@ import TorusController, { DEFAULT_CONFIG, DEFAULT_STATE, EPHERMAL_KEY } from "@/
 import { i18n } from "@/plugins/i18nPlugin";
 import installStorePlugin from "@/plugins/persistPlugin";
 import { WALLET_SUPPORTED_NETWORKS } from "@/utils/const";
-import { CONTROLLER_MODULE_KEY, LOCAL_STORAGE_KEY, TorusControllerState } from "@/utils/enums";
+import { CONTROLLER_MODULE_KEY, SESSION_STORAGE_KEY, TorusControllerState } from "@/utils/enums";
 import { delay, isMain } from "@/utils/helpers";
 import { NAVBAR_MESSAGES } from "@/utils/messages";
 
@@ -409,6 +409,7 @@ class ControllerModule extends VuexModule {
     this.torus.on("store", (_state: TorusControllerState) => {
       this.updateTorusState(_state);
     });
+
     // this.torus.setupUntrustedCommunication();
     // Good
     this.torus.on(TX_EVENTS.TX_UNAPPROVED, async ({ txMeta, req }) => {
@@ -520,6 +521,7 @@ class ControllerModule extends VuexModule {
       const sessionOverride = sessionStorage.getItem("dappOriginURL");
       const dappStorageKey = sessionOverride || this.torus.origin;
       window.localStorage?.removeItem(`${EPHERMAL_KEY}-${dappStorageKey}`);
+      window.sessionStorage?.removeItem(`${EPHERMAL_KEY}-${dappStorageKey}`);
     } catch (error) {
       log.error(new Error("LocalStorage unavailable"));
     }
@@ -660,7 +662,7 @@ class ControllerModule extends VuexModule {
 const moduleName = `${CONTROLLER_MODULE_KEY}`;
 installStorePlugin({
   key: moduleName,
-  storage: LOCAL_STORAGE_KEY,
+  storage: SESSION_STORAGE_KEY,
   saveState: (key: string, state: Record<string, unknown>, storage?: Storage) => {
     const requiredState = omit(state, [`${moduleName}.torus`, `${moduleName}.requireKeyRestore`, `${moduleName}.torusState.KeyringControllerState`]);
     storage?.setItem(key, JSON.stringify(requiredState));

--- a/src/modules/controllers.ts
+++ b/src/modules/controllers.ts
@@ -522,8 +522,9 @@ class ControllerModule extends VuexModule {
       const sessionOverride = sessionStorage.getItem("dappOriginURL");
       const dappStorageKey = sessionOverride || this.torus.origin;
       window.localStorage?.removeItem(`${EPHERMAL_KEY}-${dappStorageKey}`);
-      window.sessionStorage?.removeItem(`${EPHERMAL_KEY}-${dappStorageKey}`);
+      window.sessionStorage?.removeItem(`${EPHERMAL_KEY}`);
       window.sessionStorage?.removeItem("dappOriginURL");
+      window.sessionStorage?.removeItem("w3aClientID");
     } catch (error) {
       log.error(new Error("LocalStorage unavailable"));
     }

--- a/src/modules/controllers.ts
+++ b/src/modules/controllers.ts
@@ -485,6 +485,7 @@ class ControllerModule extends VuexModule {
 
   @Action
   async logout(): Promise<void> {
+    log.info("logout");
     if (isMain && this.selectedAddress) {
       this.openloginLogout();
     }
@@ -522,6 +523,7 @@ class ControllerModule extends VuexModule {
       const dappStorageKey = sessionOverride || this.torus.origin;
       window.localStorage?.removeItem(`${EPHERMAL_KEY}-${dappStorageKey}`);
       window.sessionStorage?.removeItem(`${EPHERMAL_KEY}-${dappStorageKey}`);
+      window.sessionStorage?.removeItem("dappOriginURL");
     } catch (error) {
       log.error(new Error("LocalStorage unavailable"));
     }

--- a/src/modules/controllers.ts
+++ b/src/modules/controllers.ts
@@ -41,7 +41,7 @@ import TorusController, { DEFAULT_CONFIG, DEFAULT_STATE, EPHERMAL_KEY } from "@/
 import { i18n } from "@/plugins/i18nPlugin";
 import installStorePlugin from "@/plugins/persistPlugin";
 import { WALLET_SUPPORTED_NETWORKS } from "@/utils/const";
-import { CONTROLLER_MODULE_KEY, SESSION_STORAGE_KEY, TorusControllerState } from "@/utils/enums";
+import { CONTROLLER_MODULE_KEY, LOCAL_STORAGE_KEY, TorusControllerState } from "@/utils/enums";
 import { delay, isMain } from "@/utils/helpers";
 import { NAVBAR_MESSAGES } from "@/utils/messages";
 
@@ -664,7 +664,7 @@ class ControllerModule extends VuexModule {
 const moduleName = `${CONTROLLER_MODULE_KEY}`;
 installStorePlugin({
   key: moduleName,
-  storage: SESSION_STORAGE_KEY,
+  storage: LOCAL_STORAGE_KEY,
   saveState: (key: string, state: Record<string, unknown>, storage?: Storage) => {
     const requiredState = omit(state, [`${moduleName}.torus`, `${moduleName}.requireKeyRestore`, `${moduleName}.torusState.KeyringControllerState`]);
     storage?.setItem(key, JSON.stringify(requiredState));

--- a/src/pages/End.vue
+++ b/src/pages/End.vue
@@ -22,7 +22,7 @@ async function endLogin() {
 
     const openLoginInstance = await OpenLoginFactory.getInstance();
     const openLoginState = openLoginInstance.state;
-    const { privKey } = openLoginState;
+    const { privKey, tKey } = openLoginState;
 
     if (!privKey) {
       throw new Error("Login unsuccessful");
@@ -40,6 +40,7 @@ async function endLogin() {
       data: {
         userInfo,
         privKey,
+        tKey,
       },
     } as PopupData<OpenLoginPopupResponse>);
   } catch (error) {

--- a/src/pages/Frame.vue
+++ b/src/pages/Frame.vue
@@ -56,8 +56,11 @@ function startLogin() {
         initParams.extraParams = extraParams;
 
         // retain params in session (on refresh)
-        if (extraParams.w3aClientID) sessionStorage.setItem("w3aClientID", extraParams.w3aClientID);
-        if (extraParams.dappOriginURL) sessionStorage.setItem("dappOriginURL", extraParams.dappOriginURL);
+        if (extraParams.parentSearch) {
+          const parentSearch = new URLSearchParams(extraParams.parentSearch);
+          const dappOriginURL = parentSearch.get("dappOriginURL");
+          if (dappOriginURL) sessionStorage.setItem("dappOriginURL", dappOriginURL);
+        }
         if (resolve) resolve();
       }
     };

--- a/src/pages/Frame.vue
+++ b/src/pages/Frame.vue
@@ -54,6 +54,10 @@ function startLogin() {
         initParams.apiKey = apiKey;
         initParams.dappMetadata = dappMetadata;
         initParams.extraParams = extraParams;
+
+        // retain params in session (on refresh)
+        if (extraParams.w3aClientID) sessionStorage.setItem("w3aClientID", extraParams.w3aClientID);
+        if (extraParams.dappOriginURL) sessionStorage.setItem("dappOriginURL", extraParams.dappOriginURL);
         if (resolve) resolve();
       }
     };

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -4,7 +4,7 @@ import Loader from "@toruslabs/vue-components/common/Loader.vue";
 import { useVuelidate } from "@vuelidate/core";
 import { email, required } from "@vuelidate/validators";
 import log from "loglevel";
-import { computed, onMounted, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 
@@ -37,7 +37,7 @@ const $v = useVuelidate(rules, { userEmail });
 
 const selectedAddress = computed(() => ControllerModule.hasSelectedPrivateKey);
 
-onMounted(() => {
+watch(selectedAddress, () => {
   if (selectedAddress.value && isRedirectFlow)
     redirectToResult(jsonrpc, { success: true, data: { selectedAddress: selectedAddress.value }, method }, req_id, resolveRoute);
   if (selectedAddress.value && !isRedirectFlow) router.push("/wallet/home");

--- a/src/pages/wallet/Discover.vue
+++ b/src/pages/wallet/Discover.vue
@@ -36,8 +36,12 @@ onMounted(async () => {
         if (dappOriginURL) {
           const dappUrl = redirectUrl.value;
           localStorage.setItem(`dappOriginURL-${dappUrl.origin}`, dappOriginURL);
+          redirectUrl.value.searchParams.append("dappOriginURL", dappOriginURL);
         }
 
+        if (route.query.w3aClientID) {
+          redirectUrl.value.searchParams.append("w3aClientID", route.query.w3aClientID as string);
+        }
         window.location.href = redirectUrl.value.href;
       }
     }
@@ -59,7 +63,7 @@ const categoryList = computed(() => {
     ALL_CATEGORIES,
     ...new Set(
       dapps.value
-        .reduce((categories, dapp) => {
+        .reduce((categories: { value: string; label: string }[], dapp) => {
           if (dapp?.category?.length) {
             const found = categories.find((category: { value: string; label: string }) => category.value === dapp.category);
             if (!found)

--- a/src/pages/wallet/Discover.vue
+++ b/src/pages/wallet/Discover.vue
@@ -30,17 +30,10 @@ onMounted(async () => {
       redirectUrl.value = new URL(route.query.url as string);
       if (redirectUrl.value) {
         const searchParams = new URLSearchParams(window.location.search);
-        const instanceId = searchParams.get("instanceId") || "";
-        const dappOriginURL = sessionStorage.getItem(instanceId);
+        const dappOriginURL = searchParams.get("dappOriginURL") || "";
 
         if (dappOriginURL) {
-          const dappUrl = redirectUrl.value;
-          localStorage.setItem(`dappOriginURL-${dappUrl.origin}`, dappOriginURL);
           redirectUrl.value.searchParams.append("dappOriginURL", dappOriginURL);
-        }
-
-        if (route.query.w3aClientID) {
-          redirectUrl.value.searchParams.append("w3aClientID", route.query.w3aClientID as string);
         }
         window.location.href = redirectUrl.value.href;
       }

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -43,6 +43,7 @@ export type OpenLoginPopupResponse = {
 export interface KeyState {
   priv_key: string;
   pub_key: string;
+  selectedAddress: string;
 }
 
 export interface OpenLoginBackendState {

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -38,6 +38,7 @@ export const FEATURES_DEFAULT_POPUP_WINDOW = "directories=0,titlebar=0,toolbar=0
 export type OpenLoginPopupResponse = {
   userInfo: OpenloginUserInfo;
   privKey: string;
+  tKey: string;
 };
 
 export interface KeyState {

--- a/tests/controller/mockData.ts
+++ b/tests/controller/mockData.ts
@@ -27,6 +27,7 @@ export const sKeyPair = [
 export const openloginFaker = [
   {
     privKey: secp256[0].getPrivate().toString("hex"),
+    tKey: secp256[0].getPrivate().toString("hex"),
     userInfo: {
       email: "testing@tor.us",
       name: "testing",
@@ -39,6 +40,7 @@ export const openloginFaker = [
   },
   {
     privKey: secp256[1].getPrivate().toString("hex"),
+    tKey: secp256[0].getPrivate().toString("hex"),
     userInfo: {
       email: "testing11@tor.us",
       name: "testing11",
@@ -51,6 +53,7 @@ export const openloginFaker = [
   },
   {
     privKey: secp256[2].getPrivate().toString("hex"),
+    tKey: secp256[0].getPrivate().toString("hex"),
     userInfo: {
       email: "testing22@tor.us",
       name: "testing22",


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Support dapp derive key as selected key
Support brave and safari browser popup

require embed PR
https://github.com/torusresearch/solana-embed/pull/48


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Safari and brave unable to restore on popup
unable to pass/communicate with new apps' iframe (wallet)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Support safari and brave popup
- pass clientID/dapp domain for dapp key injection
-
-

## Other information
require Solana-embed PR https://github.com/torusresearch/solana-embed/pull/48

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
