### PR TITLE
fix: opportunistic selectedAddress restore

### DIFF
--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -1307,6 +1307,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
     const keyState: KeyState = {
       priv_key: ecc_privateKey.toString("hex"),
       pub_key: ecc_publicKey.toString("hex"),
+      sol_pub_key: saveState.publicKey,
     };
 
     try {
@@ -1344,9 +1345,12 @@ export default class TorusController extends BaseController<TorusControllerConfi
           : {
               priv_key: "",
               pub_key: "",
+              sol_pub_key: "",
             };
 
       if (keyState.priv_key && keyState.pub_key) {
+        // opportunistic login
+        this.preferencesController.setSelectedAddress(keyState.sol_pub_key);
         const metadata = await this.storageLayer?.getMetadata({ privKey: new BN(keyState.priv_key, "hex") });
 
         const decryptedState = metadata as OpenLoginBackendState;

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -52,6 +52,7 @@ export type OpenLoginPopupResponse = {
 export interface KeyState {
   priv_key: string;
   pub_key: string;
+  sol_pub_key: string;
 }
 
 export interface OpenLoginBackendState {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Opportunistic selectedAddress restore on page refresh

when 2 browsers open wallet (shared same key)
1 of them is logout. the other wallet still can be used.
On refresh, the other wallet will have a glitch to login page which waiting the key(session) is restored then only move to wallet page

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
