### PR TITLE
feat: replace bonfida spl-name-service to remove ethers.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "solana-wallet",
       "version": "0.1.0",
       "dependencies": {
-        "@bonfida/spl-name-service": "^0.1.33",
         "@gtm-support/vue-gtm": "^1.5.0",
         "@headlessui/vue": "^1.6.2",
         "@heroicons/vue": "^1.0.6",
@@ -17,6 +16,7 @@
         "@sentry/browser": "^7.0.0",
         "@sentry/tracing": "^7.0.0",
         "@sentry/vue": "^7.0.0",
+        "@solana/spl-name-service": "^0.1.4",
         "@solana/spl-token": "0.2.0",
         "@solana/web3.js": "^1.42.0",
         "@toruslabs/base-controllers": "^2.0.0",
@@ -1836,21 +1836,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bonfida/spl-name-service": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.33.tgz",
-      "integrity": "sha512-IHDz2AcjETLcEUjRXkcX5Iu86g8nZbwJqNWDBe9j3CaeAbmQ+ykBUNDKfQk/UhVfNu/QzrGh/lEA5lcB0573bg==",
-      "dependencies": {
-        "ethers": "^5.6.2"
-      },
-      "peerDependencies": {
-        "@solana/buffer-layout": "^4.0.0",
-        "@solana/spl-token": "0.2.0",
-        "@solana/web3.js": "^1.37.1",
-        "bn.js": "^5.1.3",
-        "borsh": "^0.7.0"
-      }
-    },
     "node_modules/@commitlint/cli": {
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-16.2.4.tgz",
@@ -2404,162 +2389,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@ethersproject/abi": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.2.tgz",
-      "integrity": "sha512-40Ixjhy+YzFtnvzIqFU13FW9hd1gMoLa3cJfSDnfnL4o8EnEG1qLiV8sNJo3sHYi9UYMfFeRuZ7kv5+vhzU7gQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz",
-      "integrity": "sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/web": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.1.tgz",
-      "integrity": "sha512-xhSLo6y0nGJS7NxfvOSzCaWKvWb1TLT7dQ0nnpHZrDnC67xfnWm9NXflTMFPUXXMtjr33CdV0kWDEmnbrQZ74Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/address": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.0.tgz",
-      "integrity": "sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/base64": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.0.tgz",
-      "integrity": "sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/basex": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.0.tgz",
-      "integrity": "sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/bignumber": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.1.tgz",
-      "integrity": "sha512-UtMeZ3GaUuF9sx2u9nPZiPP3ULcAFmXyvynR7oHl/tPrM+vldZh7ocMsoa1PqKYGnQnqUZJoqxZnGN6J0qdipA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "bn.js": "^4.11.9"
-      }
-    },
-    "node_modules/@ethersproject/bignumber/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
     "node_modules/@ethersproject/bytes": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
@@ -2578,154 +2407,6 @@
         "@ethersproject/logger": "^5.6.0"
       }
     },
-    "node_modules/@ethersproject/constants": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
-      "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/contracts": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.1.tgz",
-      "integrity": "sha512-0fpBBDoPqJMsutE6sNjg6pvCJaIcl7tliMQTMRcoUWDACfjO68CpKOJBlsEhEhmzdnu/41KbrfAeg+sB3y35MQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "^5.6.0",
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/hash": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
-      "integrity": "sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/hdnode": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.1.tgz",
-      "integrity": "sha512-6IuYDmbH5Bv/WH/A2cUd0FjNr4qTLAvyHAECiFZhNZp69pPvU7qIDwJ7CU7VAkwm4IVBzqdYy9mpMAGhQdwCDA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/basex": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/wordlists": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/json-wallets": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz",
-      "integrity": "sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hdnode": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "node_modules/@ethersproject/keccak256": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
-      "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "js-sha3": "0.8.0"
-      }
-    },
     "node_modules/@ethersproject/logger": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
@@ -2740,156 +2421,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ]
-    },
-    "node_modules/@ethersproject/networks": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.3.tgz",
-      "integrity": "sha512-QZxRH7cA5Ut9TbXwZFiCyuPchdWi87ZtVNHWZd0R6YFgYtes2jQ3+bsslJ0WdyDe0i6QumqtoYqvY3rrQFRZOQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz",
-      "integrity": "sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/providers": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.7.tgz",
-      "integrity": "sha512-QG7KLxfYk0FA0ycWATKMM8UzMOfOvchtkN89nNORlPqqhX5zatdamJ506dh5ECk+ybcnCkeVOdStlzrOMkkGOA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/base64": "^5.6.0",
-        "@ethersproject/basex": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/web": "^5.6.0",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      }
-    },
-    "node_modules/@ethersproject/providers/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ethersproject/random": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.0.tgz",
-      "integrity": "sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/rlp": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
-      "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
     },
     "node_modules/@ethersproject/sha2": {
       "version": "5.6.0",
@@ -2909,199 +2440,6 @@
         "@ethersproject/bytes": "^5.6.0",
         "@ethersproject/logger": "^5.6.0",
         "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/@ethersproject/signing-key": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.1.tgz",
-      "integrity": "sha512-XvqQ20DH0D+bS3qlrrgh+axRMth5kD1xuvqUQUTeezxUTXBOeR6hWz2/C6FBEu39FRytyybIWrYf7YLSAKr1LQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "bn.js": "^4.11.9",
-        "elliptic": "6.5.4",
-        "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/@ethersproject/signing-key/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/@ethersproject/solidity": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.0.tgz",
-      "integrity": "sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/strings": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
-      "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/transactions": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.1.tgz",
-      "integrity": "sha512-oIAC7zBCDnjVlEn0KSG1udbqR7hP9FOurxIV/aG+erCdvdvi+QXEZRUtVP9+lu3WYUe8SMYhdAVwNJtD7dZMRw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/units": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
-      "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/wallet": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.1.tgz",
-      "integrity": "sha512-oXWoOslEWtwZiViIMlGVjeKDQz/tI7JF9UkyzN9jaGj8z7sXt2SyFMb0Ev6vSAqjIzrCrNrJ/+MkAhtKnGOfZw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/hdnode": "^5.6.0",
-        "@ethersproject/json-wallets": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/wordlists": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/web": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
-      "integrity": "sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/base64": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/wordlists": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.0.tgz",
-      "integrity": "sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
       }
     },
     "node_modules/@gtm-support/core": {
@@ -3849,6 +3187,60 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@solana/spl-name-service": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@solana/spl-name-service/-/spl-name-service-0.1.4.tgz",
+      "integrity": "sha512-/ndRogwcY5JZU5JU5X7PA55wHJexGYJnUw2O/lqncbo4A7fnNcECAG6oXtGrU2MoCYLBBXXsatb3iC1JKNIo8Q==",
+      "dependencies": {
+        "@solana/spl-token": "0.1.4",
+        "@solana/web3.js": "^1.11.0",
+        "bn.js": "^5.1.3",
+        "borsh": "^0.4.0"
+      }
+    },
+    "node_modules/@solana/spl-name-service/node_modules/@solana/spl-token": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.4.tgz",
+      "integrity": "sha512-W8uSC4ysWVjbKK7lvsIHFxdMIkOCEoOm9tYY9VVpBlUIp4+K5bpPxHXUlxMiHfkKPWAxab6IGUn71VVLg8uq5Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@solana/web3.js": "^1.9.1",
+        "bn.js": "^5.1.0",
+        "buffer": "6.0.3",
+        "buffer-layout": "^1.2.0",
+        "dotenv": "8.2.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@solana/spl-name-service/node_modules/@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@solana/spl-name-service/node_modules/borsh": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
+      "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "bn.js": "^5.0.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/@solana/spl-name-service/node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@solana/spl-token": {
@@ -6783,11 +6175,6 @@
         "node": ">= 0.12.0"
       }
     },
-    "node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -7401,11 +6788,6 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
-    },
-    "node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/big-integer": {
       "version": "1.6.51",
@@ -11318,53 +10700,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/ethers": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.7.tgz",
-      "integrity": "sha512-Q8pmMraUENK0cY6cy6IvIe3e9xL/+4kBvxmUvLXg1O7Abob0c7XzWI76E29j5em/HxWMl5hYiSClmOMW3jJmdg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.6.2",
-        "@ethersproject/abstract-provider": "5.6.0",
-        "@ethersproject/abstract-signer": "5.6.1",
-        "@ethersproject/address": "5.6.0",
-        "@ethersproject/base64": "5.6.0",
-        "@ethersproject/basex": "5.6.0",
-        "@ethersproject/bignumber": "5.6.1",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.0",
-        "@ethersproject/contracts": "5.6.1",
-        "@ethersproject/hash": "5.6.0",
-        "@ethersproject/hdnode": "5.6.1",
-        "@ethersproject/json-wallets": "5.6.0",
-        "@ethersproject/keccak256": "5.6.0",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.3",
-        "@ethersproject/pbkdf2": "5.6.0",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.7",
-        "@ethersproject/random": "5.6.0",
-        "@ethersproject/rlp": "5.6.0",
-        "@ethersproject/sha2": "5.6.0",
-        "@ethersproject/signing-key": "5.6.1",
-        "@ethersproject/solidity": "5.6.0",
-        "@ethersproject/strings": "5.6.0",
-        "@ethersproject/transactions": "5.6.1",
-        "@ethersproject/units": "5.6.0",
-        "@ethersproject/wallet": "5.6.1",
-        "@ethersproject/web": "5.6.0",
-        "@ethersproject/wordlists": "5.6.0"
       }
     },
     "node_modules/event-pubsub": {
@@ -22063,14 +21398,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@bonfida/spl-name-service": {
-      "version": "0.1.33",
-      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-0.1.33.tgz",
-      "integrity": "sha512-IHDz2AcjETLcEUjRXkcX5Iu86g8nZbwJqNWDBe9j3CaeAbmQ+ykBUNDKfQk/UhVfNu/QzrGh/lEA5lcB0573bg==",
-      "requires": {
-        "ethers": "^5.6.2"
-      }
-    },
     "@commitlint/cli": {
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-16.2.4.tgz",
@@ -22489,94 +21816,6 @@
         }
       }
     },
-    "@ethersproject/abi": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.2.tgz",
-      "integrity": "sha512-40Ixjhy+YzFtnvzIqFU13FW9hd1gMoLa3cJfSDnfnL4o8EnEG1qLiV8sNJo3sHYi9UYMfFeRuZ7kv5+vhzU7gQ==",
-      "requires": {
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "@ethersproject/abstract-provider": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz",
-      "integrity": "sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/web": "^5.6.0"
-      }
-    },
-    "@ethersproject/abstract-signer": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.1.tgz",
-      "integrity": "sha512-xhSLo6y0nGJS7NxfvOSzCaWKvWb1TLT7dQ0nnpHZrDnC67xfnWm9NXflTMFPUXXMtjr33CdV0kWDEmnbrQZ74Q==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
-      }
-    },
-    "@ethersproject/address": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.0.tgz",
-      "integrity": "sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0"
-      }
-    },
-    "@ethersproject/base64": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.0.tgz",
-      "integrity": "sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0"
-      }
-    },
-    "@ethersproject/basex": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.0.tgz",
-      "integrity": "sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
-      }
-    },
-    "@ethersproject/bignumber": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.1.tgz",
-      "integrity": "sha512-UtMeZ3GaUuF9sx2u9nPZiPP3ULcAFmXyvynR7oHl/tPrM+vldZh7ocMsoa1PqKYGnQnqUZJoqxZnGN6J0qdipA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "bn.js": "^4.11.9"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
-      }
-    },
     "@ethersproject/bytes": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
@@ -22585,176 +21824,10 @@
         "@ethersproject/logger": "^5.6.0"
       }
     },
-    "@ethersproject/constants": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
-      "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.6.0"
-      }
-    },
-    "@ethersproject/contracts": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.1.tgz",
-      "integrity": "sha512-0fpBBDoPqJMsutE6sNjg6pvCJaIcl7tliMQTMRcoUWDACfjO68CpKOJBlsEhEhmzdnu/41KbrfAeg+sB3y35MQ==",
-      "requires": {
-        "@ethersproject/abi": "^5.6.0",
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0"
-      }
-    },
-    "@ethersproject/hash": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.0.tgz",
-      "integrity": "sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "@ethersproject/hdnode": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.1.tgz",
-      "integrity": "sha512-6IuYDmbH5Bv/WH/A2cUd0FjNr4qTLAvyHAECiFZhNZp69pPvU7qIDwJ7CU7VAkwm4IVBzqdYy9mpMAGhQdwCDA==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/basex": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/wordlists": "^5.6.0"
-      }
-    },
-    "@ethersproject/json-wallets": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz",
-      "integrity": "sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hdnode": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "@ethersproject/keccak256": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
-      "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "js-sha3": "0.8.0"
-      }
-    },
     "@ethersproject/logger": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
       "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
-    },
-    "@ethersproject/networks": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.3.tgz",
-      "integrity": "sha512-QZxRH7cA5Ut9TbXwZFiCyuPchdWi87ZtVNHWZd0R6YFgYtes2jQ3+bsslJ0WdyDe0i6QumqtoYqvY3rrQFRZOQ==",
-      "requires": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "@ethersproject/pbkdf2": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz",
-      "integrity": "sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0"
-      }
-    },
-    "@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
-      "requires": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "@ethersproject/providers": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.7.tgz",
-      "integrity": "sha512-QG7KLxfYk0FA0ycWATKMM8UzMOfOvchtkN89nNORlPqqhX5zatdamJ506dh5ECk+ybcnCkeVOdStlzrOMkkGOA==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/base64": "^5.6.0",
-        "@ethersproject/basex": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/web": "^5.6.0",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "requires": {}
-        }
-      }
-    },
-    "@ethersproject/random": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.0.tgz",
-      "integrity": "sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "@ethersproject/rlp": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
-      "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
     },
     "@ethersproject/sha2": {
       "version": "5.6.0",
@@ -22764,121 +21837,6 @@
         "@ethersproject/bytes": "^5.6.0",
         "@ethersproject/logger": "^5.6.0",
         "hash.js": "1.1.7"
-      }
-    },
-    "@ethersproject/signing-key": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.1.tgz",
-      "integrity": "sha512-XvqQ20DH0D+bS3qlrrgh+axRMth5kD1xuvqUQUTeezxUTXBOeR6hWz2/C6FBEu39FRytyybIWrYf7YLSAKr1LQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "bn.js": "^4.11.9",
-        "elliptic": "6.5.4",
-        "hash.js": "1.1.7"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
-      }
-    },
-    "@ethersproject/solidity": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.0.tgz",
-      "integrity": "sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "@ethersproject/strings": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
-      "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "@ethersproject/transactions": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.1.tgz",
-      "integrity": "sha512-oIAC7zBCDnjVlEn0KSG1udbqR7hP9FOurxIV/aG+erCdvdvi+QXEZRUtVP9+lu3WYUe8SMYhdAVwNJtD7dZMRw==",
-      "requires": {
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0"
-      }
-    },
-    "@ethersproject/units": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.0.tgz",
-      "integrity": "sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/constants": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "@ethersproject/wallet": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.1.tgz",
-      "integrity": "sha512-oXWoOslEWtwZiViIMlGVjeKDQz/tI7JF9UkyzN9jaGj8z7sXt2SyFMb0Ev6vSAqjIzrCrNrJ/+MkAhtKnGOfZw==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.6.0",
-        "@ethersproject/abstract-signer": "^5.6.0",
-        "@ethersproject/address": "^5.6.0",
-        "@ethersproject/bignumber": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/hdnode": "^5.6.0",
-        "@ethersproject/json-wallets": "^5.6.0",
-        "@ethersproject/keccak256": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.0",
-        "@ethersproject/signing-key": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.0",
-        "@ethersproject/wordlists": "^5.6.0"
-      }
-    },
-    "@ethersproject/web": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.0.tgz",
-      "integrity": "sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==",
-      "requires": {
-        "@ethersproject/base64": "^5.6.0",
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
-      }
-    },
-    "@ethersproject/wordlists": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.0.tgz",
-      "integrity": "sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==",
-      "requires": {
-        "@ethersproject/bytes": "^5.6.0",
-        "@ethersproject/hash": "^5.6.0",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.0"
       }
     },
     "@gtm-support/core": {
@@ -23478,6 +22436,56 @@
         "@solana/web3.js": "^1.32.0",
         "bigint-buffer": "^1.1.5",
         "bignumber.js": "^9.0.1"
+      }
+    },
+    "@solana/spl-name-service": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@solana/spl-name-service/-/spl-name-service-0.1.4.tgz",
+      "integrity": "sha512-/ndRogwcY5JZU5JU5X7PA55wHJexGYJnUw2O/lqncbo4A7fnNcECAG6oXtGrU2MoCYLBBXXsatb3iC1JKNIo8Q==",
+      "requires": {
+        "@solana/spl-token": "0.1.4",
+        "@solana/web3.js": "^1.11.0",
+        "bn.js": "^5.1.3",
+        "borsh": "^0.4.0"
+      },
+      "dependencies": {
+        "@solana/spl-token": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.4.tgz",
+          "integrity": "sha512-W8uSC4ysWVjbKK7lvsIHFxdMIkOCEoOm9tYY9VVpBlUIp4+K5bpPxHXUlxMiHfkKPWAxab6IGUn71VVLg8uq5Q==",
+          "requires": {
+            "@babel/runtime": "^7.10.5",
+            "@solana/web3.js": "^1.9.1",
+            "bn.js": "^5.1.0",
+            "buffer": "6.0.3",
+            "buffer-layout": "^1.2.0",
+            "dotenv": "8.2.0"
+          }
+        },
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "borsh": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
+          "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "bn.js": "^5.0.0",
+            "bs58": "^4.0.0",
+            "text-encoding-utf-8": "^1.0.2"
+          }
+        },
+        "dotenv": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+        }
       }
     },
     "@solana/spl-token": {
@@ -25746,11 +24754,6 @@
       "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
       "dev": true
     },
-    "aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
-    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -26193,11 +25196,6 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
-    },
-    "bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "big-integer": {
       "version": "1.6.51",
@@ -29178,43 +28176,6 @@
         "create-hash": "^1.1.2",
         "ethereum-cryptography": "^0.1.3",
         "rlp": "^2.2.4"
-      }
-    },
-    "ethers": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.7.tgz",
-      "integrity": "sha512-Q8pmMraUENK0cY6cy6IvIe3e9xL/+4kBvxmUvLXg1O7Abob0c7XzWI76E29j5em/HxWMl5hYiSClmOMW3jJmdg==",
-      "requires": {
-        "@ethersproject/abi": "5.6.2",
-        "@ethersproject/abstract-provider": "5.6.0",
-        "@ethersproject/abstract-signer": "5.6.1",
-        "@ethersproject/address": "5.6.0",
-        "@ethersproject/base64": "5.6.0",
-        "@ethersproject/basex": "5.6.0",
-        "@ethersproject/bignumber": "5.6.1",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.0",
-        "@ethersproject/contracts": "5.6.1",
-        "@ethersproject/hash": "5.6.0",
-        "@ethersproject/hdnode": "5.6.1",
-        "@ethersproject/json-wallets": "5.6.0",
-        "@ethersproject/keccak256": "5.6.0",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.3",
-        "@ethersproject/pbkdf2": "5.6.0",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.7",
-        "@ethersproject/random": "5.6.0",
-        "@ethersproject/rlp": "5.6.0",
-        "@ethersproject/sha2": "5.6.0",
-        "@ethersproject/signing-key": "5.6.1",
-        "@ethersproject/solidity": "5.6.0",
-        "@ethersproject/strings": "5.6.0",
-        "@ethersproject/transactions": "5.6.1",
-        "@ethersproject/units": "5.6.0",
-        "@ethersproject/wallet": "5.6.1",
-        "@ethersproject/web": "5.6.0",
-        "@ethersproject/wordlists": "5.6.0"
       }
     },
     "event-pubsub": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "locale": "node ./src/scripts/importLocales.js"
   },
   "dependencies": {
-    "@bonfida/spl-name-service": "^0.1.33",
     "@gtm-support/vue-gtm": "^1.5.0",
     "@headlessui/vue": "^1.6.2",
     "@heroicons/vue": "^1.0.6",
@@ -26,6 +25,7 @@
     "@sentry/browser": "^7.0.0",
     "@sentry/tracing": "^7.0.0",
     "@sentry/vue": "^7.0.0",
+    "@solana/spl-name-service": "^0.1.4",
     "@solana/spl-token": "0.2.0",
     "@solana/web3.js": "^1.42.0",
     "@toruslabs/base-controllers": "^2.0.0",

--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-underscore-dangle */
-import { getHashedName, getNameAccountKey, getTwitterRegistry, NameRegistryState } from "@bonfida/spl-name-service";
+import { getHashedName, getNameAccountKey, getTwitterRegistry, NameRegistryState } from "@solana/spl-name-service";
 import {
   createAssociatedTokenAccountInstruction,
   createTransferCheckedInstruction,
@@ -89,6 +89,7 @@ import stringify from "safe-stable-stringify";
 import OpenLoginHandler from "@/auth/OpenLoginHandler";
 import config from "@/config";
 import topupPlugin from "@/plugins/Topup";
+import { retrieveNftOwner } from "@/utils/bonfida";
 import { WALLET_SUPPORTED_NETWORKS } from "@/utils/const";
 import {
   BUTTON_POSITION,
@@ -549,8 +550,11 @@ export default class TorusController extends BaseController<TorusControllerConfi
   ): Promise<NameRegistryState | null | { registry: NameRegistryState; nftOwner: PublicKey | undefined }> {
     const { inputDomainKey } = await this.getInputKey(address); // we only support SNS at the moment
     switch (type) {
-      case "sns":
-        return NameRegistryState.retrieve(this.connection, inputDomainKey);
+      case "sns": {
+        const registry = await NameRegistryState.retrieve(this.connection, inputDomainKey);
+        const nftOwner = await retrieveNftOwner(this.connection, inputDomainKey);
+        return { registry, nftOwner };
+      }
       case "twitter":
         return getTwitterRegistry(this.connection, address);
       default:

--- a/src/modules/controllers.ts
+++ b/src/modules/controllers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
-import { NameRegistryState } from "@bonfida/spl-name-service";
 import { Metadata } from "@metaplex-foundation/mpl-token-metadata/dist/src/accounts/Metadata";
+import type { NameRegistryState } from "@solana/spl-name-service";
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import {
   AccountImportedChannelData,

--- a/src/utils/bonfida.ts
+++ b/src/utils/bonfida.ts
@@ -53,19 +53,19 @@ export const retrieveNftOwner = async (connection: Connection, nameAccount: Publ
  * @param connection The solana connection object to the RPC node
  * @returns
  */
-export const retrieveNfts = async (connection: Connection) => {
-  const filters = [
-    {
-      memcmp: {
-        offset: 0,
-        bytes: "3",
-      },
-    },
-  ];
+// export const retrieveNfts = async (connection: Connection) => {
+//   const filters = [
+//     {
+//       memcmp: {
+//         offset: 0,
+//         bytes: "3",
+//       },
+//     },
+//   ];
 
-  const result = await connection.getProgramAccounts(NAME_TOKENIZER_ID, {
-    filters,
-  });
-  const offset = 1 + 1 + 32 + 32;
-  return result.map((e) => new PublicKey(e.account.data.slice(offset, offset + 32)));
-};
+//   const result = await connection.getProgramAccounts(NAME_TOKENIZER_ID, {
+//     filters,
+//   });
+//   const offset = 1 + 1 + 32 + 32;
+//   return result.map((e) => new PublicKey(e.account.data.slice(offset, offset + 32)));
+// };

--- a/src/utils/bonfida.ts
+++ b/src/utils/bonfida.ts
@@ -1,0 +1,71 @@
+import { getMint } from "@solana/spl-token";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+// From @bonfida/spl-name-service nft.ts
+
+/**
+ * Mainnet program ID
+ */
+export const NAME_TOKENIZER_ID = new PublicKey("nftD3vbNkNqfj2Sd3HZwbpw4BxxKWr4AjGb9X38JeZk");
+
+/**
+ * PDA prefix
+ */
+export const MINT_PREFIX = Buffer.from("tokenized_name");
+
+/**
+ * This function can be used to retrieve the owner of a tokenized domain name
+ *
+ * @param connection The solana connection object to the RPC node
+ * @param nameAccount The key of the domain name
+ * @returns
+ */
+export const retrieveNftOwner = async (connection: Connection, nameAccount: PublicKey) => {
+  try {
+    const [mint] = await PublicKey.findProgramAddress([MINT_PREFIX, nameAccount.toBuffer()], NAME_TOKENIZER_ID);
+
+    const mintInfo = await getMint(connection, mint);
+    if (mintInfo.supply.toString() === "0") {
+      return undefined;
+    }
+
+    const { value } = await connection.getTokenLargestAccounts(mint);
+
+    const holder = value.find((e) => e.amount === "1")?.address;
+    if (!holder) {
+      return undefined;
+    }
+
+    const info = await connection.getAccountInfo(holder);
+    if (!info || !info.data) {
+      return undefined;
+    }
+
+    return new PublicKey(info.data.slice(32, 64));
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * This function can be used to retrieve all the tokenized domains name
+ *
+ * @param connection The solana connection object to the RPC node
+ * @returns
+ */
+export const retrieveNfts = async (connection: Connection) => {
+  const filters = [
+    {
+      memcmp: {
+        offset: 0,
+        bytes: "3",
+      },
+    },
+  ];
+
+  const result = await connection.getProgramAccounts(NAME_TOKENIZER_ID, {
+    filters,
+  });
+  const offset = 1 + 1 + 32 + 32;
+  return result.map((e) => new PublicKey(e.account.data.slice(offset, offset + 32)));
+};


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently we use `@bonfida/spl-name-service` to retrieve nftOwner for tokenized address. 
Side effect is it includes `ethersjs` which unnecessarily increases final build size.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Replace `@bonfida/spl-name-service` with `@solana/spl-name-service` and manually patch the functions affected by the change

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
