### PR TITLE
fix: track selectedAddress token on pre and post

### DIFF
--- a/src/utils/solanaHelpers.ts
+++ b/src/utils/solanaHelpers.ts
@@ -175,10 +175,8 @@ export async function calculateChanges(
         rentExemptReserve: null,
       };
 
-      if (tokenDetail.owner.toBase58() === selectedAddress) {
-        mintTokenAddress.push(tokenDetail.mint.toBase58());
-        postTokenDetails.push(tokenDetail);
-      }
+      mintTokenAddress.push(tokenDetail.mint.toBase58());
+      postTokenDetails.push(tokenDetail);
     }
   });
 
@@ -206,19 +204,21 @@ export async function calculateChanges(
   // calculate token account changes
   // compare post token account with current token account.
   postTokenDetails.forEach(async (item, idx) => {
-    const mint = item.mint.toBase58();
-    const symbol = addressSlicer(item.mint.toBase58());
+    if (preTokenDetails[idx]?.owner.toBase58() === selectedAddress || item.owner.toBase58() === selectedAddress) {
+      const mint = item.mint.toBase58();
+      const symbol = addressSlicer(item.mint.toBase58());
 
-    const { decimals } = mintAccountInfos[idx];
-    const preTokenAmount = preTokenDetails[idx]?.amount || BigInt(0);
-    const changes = Number(item.amount - preTokenAmount) / 10 ** decimals;
+      const { decimals } = mintAccountInfos[idx];
+      const preTokenAmount = preTokenDetails[idx]?.amount || BigInt(0);
+      const changes = Number(item.amount - preTokenAmount) / 10 ** decimals;
 
-    returnResult.push({
-      changes: Number(changes.toString()),
-      symbol,
-      mint,
-      address: item.address.toBase58(),
-    });
+      returnResult.push({
+        changes: Number(changes.toString()),
+        symbol,
+        mint,
+        address: item.address.toBase58(),
+      });
+    }
   });
 
   // add filter new interested program and its account

--- a/src/utils/solanaHelpers.ts
+++ b/src/utils/solanaHelpers.ts
@@ -191,7 +191,7 @@ export async function calculateChanges(
   const mintAccounts = queryAccounts.slice(1, mintTokenAddress.length + 1);
   const tokenAccounts = queryAccounts.slice(mintTokenAddress.length + 1);
 
-  const mintAccountInfos: RawMint[] = mintAccounts.map((item) => MintLayout.decode(Buffer.from(item?.data || [])));
+  // const mintAccountInfos: RawMint[] = mintAccounts.map((item) => MintLayout.decode(Buffer.from(item?.data || [])));
   const preTokenDetails = tokenAccounts.map((item, _idx) => (item ? AccountLayout.decode(item.data) : null));
 
   // Check for holder's sol account balance changes
@@ -204,11 +204,27 @@ export async function calculateChanges(
   // calculate token account changes
   // compare post token account with current token account.
   postTokenDetails.forEach(async (item, idx) => {
+    // Track only tokenDetail related to selectedAddress (pre or post)
     if (preTokenDetails[idx]?.owner.toBase58() === selectedAddress || item.owner.toBase58() === selectedAddress) {
-      const mint = item.mint.toBase58();
+      let mint = item.mint.toBase58();
       const symbol = addressSlicer(item.mint.toBase58());
 
-      const { decimals } = mintAccountInfos[idx];
+      // default decimals
+      let decimals = 9;
+      const preTokenMint = preTokenDetails[idx]?.mint;
+      // incase postTokenDetail's Mint Address is system program ( account closed )
+      if (mintTokenAddress[idx] !== "11111111111111111111111111111111") {
+        const mintInfo: RawMint = MintLayout.decode(Buffer.from(mintAccounts[idx]?.data || []));
+        decimals = mintInfo.decimals;
+      } else if (preTokenMint) {
+        mint = preTokenMint.toBase58();
+        const query = await connection.getMultipleAccountsInfo([preTokenMint]);
+        const mintInfo: RawMint = MintLayout.decode(Buffer.from(query[0]?.data || []));
+        decimals = mintInfo.decimals;
+      }
+      // else throw error ?
+
+      // const { decimals } = mintAccountInfos[idx];
       const preTokenAmount = preTokenDetails[idx]?.amount || BigInt(0);
       const changes = Number(item.amount - preTokenAmount) / 10 ** decimals;
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Current implementation only track selectedAddress's TokenAccount on post simulation.
Magic Eden mutate TokenAccound's owner field during Listing thus lost tracked by estimate changes function.

fix the function to track selectedAddress's TokenAccount on pre and post simulation.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
