### PR TITLE
fix: set amount=0 when not selectedAddress

### DIFF
--- a/src/utils/solanaHelpers.ts
+++ b/src/utils/solanaHelpers.ts
@@ -205,7 +205,9 @@ export async function calculateChanges(
   // compare post token account with current token account.
   postTokenDetails.forEach(async (item, idx) => {
     // Track only tokenDetail related to selectedAddress (pre or post)
-    if (preTokenDetails[idx]?.owner.toBase58() === selectedAddress || item.owner.toBase58() === selectedAddress) {
+    const preTokenOwner = preTokenDetails[idx]?.owner.toBase58();
+    const postTokenOwner = item.owner.toBase58();
+    if (preTokenOwner === selectedAddress || postTokenOwner === selectedAddress) {
       let mint = item.mint.toBase58();
       const symbol = addressSlicer(item.mint.toBase58());
 
@@ -225,8 +227,13 @@ export async function calculateChanges(
       // else throw error ?
 
       // const { decimals } = mintAccountInfos[idx];
-      const preTokenAmount = preTokenDetails[idx]?.amount || BigInt(0);
-      const changes = Number(item.amount - preTokenAmount) / 10 ** decimals;
+      let postAmount = item.amount;
+      if (postTokenOwner !== selectedAddress) postAmount = BigInt(0);
+
+      let preTokenAmount = preTokenDetails[idx]?.amount || BigInt(0);
+      if (preTokenOwner !== selectedAddress) preTokenAmount = BigInt(0);
+
+      const changes = Number(postAmount - preTokenAmount) / 10 ** decimals;
 
       returnResult.push({
         changes: Number(changes.toString()),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
TokenAccount detail that changed owner (not selected Address) is retaining the amount.

set the detail's amount to 0 if tokenAccount holder (owner) is not selected Address

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
