### PR TITLE
fix: setting moonpay min value to 30usd

### DIFF
--- a/src/plugins/Topup/moonpay.ts
+++ b/src/plugins/Topup/moonpay.ts
@@ -127,7 +127,7 @@ const configDetails: TopUpProvider = {
   rules: {
     amount: {
       required: helpers.withMessage("Required", required),
-      minValue: helpers.withMessage("Minimum transaction amount is 10.", minValue(10)),
+      minValue: helpers.withMessage("Minimum transaction amount is 30.", minValue(30)),
       maxValue: helpers.withMessage("Maximum transaction amount is 200.", maxValue(20000)),
     },
   },


### PR DESCRIPTION
Changing moonpay min purchase value to 30 USD

https://github.com/torusresearch/solana-wallet/issues/387
this pr solves the above issue.

##bug Fix



Please check the type of change your PR introduces:

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Now the min topup value is 30 usd which aligns with moonpay's min value.

