### PR TITLE
fix: update selected account token

### DIFF
--- a/src/controllers/TorusController.ts
+++ b/src/controllers/TorusController.ts
@@ -436,7 +436,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
       if (this.preferencesController.state.selectedAddress) {
         // this.preferencesController.sync(this.preferencesController.state.selectedAddress);
         this.accountTracker.refresh();
-        this.tokensTracker.updateSolanaTokens();
+        this.tokensTracker.updateSolanaTokens(this.selectedAddress);
         this.preferencesController.updateDisplayActivities();
       }
       this.emit("newBlock", block);
@@ -727,7 +727,7 @@ export default class TorusController extends BaseController<TorusControllerConfi
     // get state from chain
     this.accountTracker.refresh();
 
-    this.tokensTracker.updateSolanaTokens();
+    this.tokensTracker.updateSolanaTokens(this.selectedAddress);
     this.preferencesController.initializeDisplayActivity();
   }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
we are having slowness on NFT page if user have multiple account ( derived account) and a lot spam nft)
This is due to the updateSolanaToken is trying to fetch token account for all derived account.
This will also trigger multiple call updateMetadata and updateTokenInfoMap.

This PR to make token query to selected account only
This will reduce number of rpc calls and time to load nft page
This require PR https://github.com/torusresearch/controllers/pull/209
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
